### PR TITLE
fix broken link to ColdBox getting started guide

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -22,7 +22,7 @@
 
 * [CF Docs](https://cfdocs.org/)
 * [Try CF](https://www.trycf.com/)
-* [ColdBox MVC](https://coldbox.ortusbooks.com/content/full/getting_started_guide/)
+* [ColdBox MVC](https://coldbox.ortusbooks.com/getting-started/getting-started-guide/)
 * [CFWheels  MVC](https://cfwheels.org/)
 * [FW/1 MVC](http://framework-one.github.io/documentation/)
 * [CommandBox CLI](https://ortus.gitbooks.io/commandbox-documentation/content/getting_started_guide.html)


### PR DESCRIPTION
Noticed this link was broken (getting 404).

I think this new one should point to where you were expecting to go 🙂 