### PR TITLE
Add auto_approve to hello-world exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,6 +10,7 @@
       "slug": "hello-world",
       "uuid": "ab04a390-0969-4a17-8081-c852b23ed88c",
       "core": false,
+      "auto_approve": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": null


### PR DESCRIPTION
This adds the auto_approve property to the hello-world 
exercise as part of preparing tracks for the v2 launch.

The current code on the server will automatically approve
hello-world exercises anyway, but that is a temporary fix
and will be removed in the future.

See exercism/cfml#84