### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -45,7 +45,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": null
+      "topics": [
+        "math"
+      ]
     },
     {
       "slug": "secret-handshake",
@@ -109,7 +111,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": null
+      "topics": [
+        "math"
+      ]
     },
     {
       "slug": "luhn",
@@ -133,7 +137,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": null
+      "topics": [
+        "math"
+      ]
     },
     {
       "slug": "grains",
@@ -157,7 +163,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": null
+      "topics": [
+        "math"
+      ]
     },
     {
       "slug": "pig-latin",


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110