### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "8dff3e83-1204-4079-87dc-5b014e629af3",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing CFML locally",
+      "blurb": "Learn how to install CFML locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "ec68370a-582c-4af6-abce-c9e2e8cab067",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn CFML",
+      "blurb": "An overview of how to get started from scratch with CFML"
+    },
+    {
+      "uuid": "87f40b8c-fb81-4376-a5f9-1db1c92df889",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the CFML track",
+      "blurb": "Learn how to test your CFML exercises on Exercism"
+    },
+    {
+      "uuid": "5d908231-fbd0-40df-a1c1-fb672f4a71df",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful CFML resources",
+      "blurb": "A collection of useful resources to help you master CFML"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
