### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/HelloWorld.cfc
+++ b/exercises/practice/hello-world/HelloWorld.cfc
@@ -1,13 +1,10 @@
-/**
-* Your implmentation of the Hello World exercise
-*/
 component {
 	
 	/**
 	* @returns A string greeting the world
 	*/
 	 function hello() {
-		return '';
+		return 'Goodbye, Mars!';
 	}
 	
 }


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46
