### PR TITLE
Fixed broken links to documentation

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -9,4 +9,4 @@ It runs in a J2EE container with many bundled libraries that make it very produc
 CFML has native support for zip files, PDF and Excel generation, E-mails, FTP, HTTP, S3 file systems, ESAPI security libraries, JDBC drivers, JSON and REST APIs.  
 
 CFML can also leverage any Java project by dropping the jars in project and directly instantiating Java objects in your code. 
-You can learn more about basic syntax and first class data types in this guide: [Modern ColdFusion (CFML) in 100 Minutes](https://www.gitbook.com/book/ortus/modern-coldfusion-cfml-in-100-minutes/details)
+You can learn more about basic syntax and first class data types in this guide: [Modern ColdFusion (CFML) in 100 Minutes](https://modern-cfml.ortusbooks.com/)

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -31,7 +31,7 @@ component accessors=true {
 
 Here are some guides for learning more about CFML
  
-* [Modern ColdFusion (CFML) in 100 Minutes](https://www.gitbook.com/book/ortus/modern-coldfusion-cfml-in-100-minutes/details)
+* [Modern ColdFusion (CFML) in 100 Minutes](https://modern-cfml.ortusbooks.com/)
 * [CF SCript Cheatsheet](http://www.petefreitag.com/cheatsheets/coldfusion/cfscript/)
 * [Learn CF In A Week](http://www.learncfinaweek.com/)
 * [CommandBox CLI Getting Started Guide](https://commandbox.ortusbooks.com/getting-started-guide)


### PR DESCRIPTION
Learn Modern ColdFusion in 100+ Minutes is a particularly useful learning resource, but the URL has changed. This PR updates ABOUT.md and LEARNING.md to link to the correct website.