### PR TITLE
Update files -> example path in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,7 +26,7 @@
       "%{pascal_slug}Test.cfc"
     ],
     "example": [
-      "Solution.cfc"
+      ".meta/Example.cfc"
     ],
     "exemplar": [
       ".meta/Exemplar.cfc"


### PR DESCRIPTION
The existing exercises store the example file as Example.cfc not Solution.cfc. I think Solution.cfc was intended to be used with the exercise generator, but the fact the exercises use Example.cfc should trump that.