### PR TITLE
Deactivate test runner (for now)

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "active": true,
   "status": {
     "concept_exercises": false,
-    "test_runner": true,
+    "test_runner": false,
     "representer": false,
     "analyzer": false
   },


### PR DESCRIPTION
Per https://forum.exercism.org/t/cfml-test-runner-regularly-timing-out/10013, I'd like to deactivate the test runner. It consistently times out, which only serves to frustrate students using the online editor. Since CFML is coming up as a featured #48in24 language, we should be pragmatic about this since students can still solve the exercises offline. 