### PR TITLE
Add collatz-conjecture

### DIFF
--- a/config.json
+++ b/config.json
@@ -445,6 +445,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4
+      },
+      {
+        "slug": "collatz-conjecture",
+        "name": "Collatz Conjecture",
+        "uuid": "91a2e23b-b743-4d62-9908-62454e6077b8",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
       }
     ]
   },

--- a/exercises/practice/collatz-conjecture/.docs/instructions.md
+++ b/exercises/practice/collatz-conjecture/.docs/instructions.md
@@ -1,0 +1,29 @@
+# Instructions
+
+The Collatz Conjecture or 3x+1 problem can be summarized as follows:
+
+Take any positive integer n.
+If n is even, divide n by 2 to get n / 2.
+If n is odd, multiply n by 3 and add 1 to get 3n + 1.
+Repeat the process indefinitely.
+The conjecture states that no matter which number you start with, you will always reach 1 eventually.
+
+Given a number n, return the number of steps required to reach 1.
+
+## Examples
+
+Starting with n = 12, the steps would be as follows:
+
+0. 12
+1. 6
+2. 3
+3. 10
+4. 5
+5. 16
+6. 8
+7. 4
+8. 2
+9. 1
+
+Resulting in 9 steps.
+So for input n = 12, the return value would be 9.

--- a/exercises/practice/collatz-conjecture/.meta/Example.cfc
+++ b/exercises/practice/collatz-conjecture/.meta/Example.cfc
@@ -1,0 +1,30 @@
+/**
+* Here is an example solution for the CollatzConjecture exercise
+*/
+component {
+	
+	/**
+	* @returns 
+	*/
+	function steps( number ) {
+		if (arguments.number <= 0) {
+            throw new Error("Only positive integers are allowed")
+        }
+
+        var step = 0
+        var working = arguments.number;
+        while (working > 1) {
+            if (working % 2 == 0) {
+                working /= 2
+            }
+            else {
+                working = 3 * working + 1
+            }
+
+            step += 1
+        }
+
+        return step
+	}
+	
+}

--- a/exercises/practice/collatz-conjecture/.meta/ExampleTest.cfc
+++ b/exercises/practice/collatz-conjecture/.meta/ExampleTest.cfc
@@ -1,0 +1,7 @@
+component extends="CollatzConjectureTest" {
+
+	function beforeAll(){
+	  SUT = createObject( 'Solution' );
+	}
+
+}

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "BNAndras"
+  ],
+  "files": {
+    "solution": [
+      "CollatzConjecture.cfc"
+    ],
+    "test": [
+      "CollatzConjectureTest.cfc"
+    ],
+    "example": [
+      ".meta/Example.cfc"
+    ]
+  },
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture.",
+  "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
+  "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"
+}

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -1,0 +1,38 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
+description = "zero steps for one"
+
+[3d76a0a6-ea84-444a-821a-f7857c2c1859]
+description = "divide if even"
+
+[754dea81-123c-429e-b8bc-db20b05a87b9]
+description = "even and odd steps"
+
+[ecfd0210-6f85-44f6-8280-f65534892ff6]
+description = "large number of even and odd steps"
+
+[7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
+description = "zero is an error"
+include = false
+
+[2187673d-77d6-4543-975e-66df6c50e2da]
+description = "zero is an error"
+reimplements = "7d4750e6-def9-4b86-aec7-9f7eb44f95a3"
+
+[c6c795bf-a288-45e9-86a1-841359ad426d]
+description = "negative value is an error"
+include = false
+
+[ec11f479-56bc-47fd-a434-bcd7a31a7a2e]
+description = "negative value is an error"
+reimplements = "c6c795bf-a288-45e9-86a1-841359ad426d"

--- a/exercises/practice/collatz-conjecture/CollatzConjecture.cfc
+++ b/exercises/practice/collatz-conjecture/CollatzConjecture.cfc
@@ -1,0 +1,13 @@
+/**
+* Your implementation of the CollatzConjecture exercise
+*/
+component {
+	
+	/**
+	* @returns 
+	*/
+	function steps( number ) {
+		// Implement me here
+	}
+	
+}

--- a/exercises/practice/collatz-conjecture/CollatzConjectureTest.cfc
+++ b/exercises/practice/collatz-conjecture/CollatzConjectureTest.cfc
@@ -1,0 +1,39 @@
+component extends="testbox.system.BaseSpec" {
+
+	function beforeAll(){
+	  SUT = createObject( 'CollatzConjecture' );
+	}
+
+	function run(){
+	
+		describe( "My CollatzConjecture class", function(){			
+
+			it( 'zero steps for one', function(){
+				expect( SUT.steps( number='1' ) ).toBe( '0' );
+			});
+
+			it( 'divide if even', function(){
+				expect( SUT.steps( number='16' ) ).toBe( '4' );
+			});
+
+			it( 'even and odd steps', function(){
+				expect( SUT.steps( number='12' ) ).toBe( '9' );
+			});
+
+			it( 'large number of even and odd steps', function(){
+				expect( SUT.steps( number='1000000' ) ).toBe( '152' );
+			});
+
+			it( 'zero is an error', function(){
+				expect( function(){ SUT.steps( number='0' ); } ).toThrow( message='Only positive integers are allowed' );
+			});
+
+			it( 'negative value is an error', function(){
+				expect( function(){ SUT.steps( number='-15' ); } ).toThrow( message='Only positive integers are allowed' );
+			});
+
+		});
+		
+	}
+ 
+}

--- a/exercises/practice/collatz-conjecture/TestRunner.cfc
+++ b/exercises/practice/collatz-conjecture/TestRunner.cfc
@@ -1,0 +1,103 @@
+/**
+* I am a CommandBox task runner which you can use to test your implementation of this exercise against the 
+* provided test suite.  To use me, open the CommandBox CLI and run this:
+* 
+* CommandBox> task run TestRunner
+*
+* To start up a test watcher that will automatically rerun the test suite every time you save a file change, run this:
+*
+* CommandBox> task run TestRunner --watcher
+*
+*/
+component {
+	
+	/**
+	* @solution Runs the tests against the solution
+	* @watcher Start up a file watch that re-runs the tests on file changes. Use Ctrl-C to stop
+	*/
+	function run( boolean solution=false, boolean watcher=false ) {
+		
+		ensureTestBox();
+
+		if( watcher ) {
+		
+			// Tabula rasa
+			command( 'cls' ).run();
+				
+			// Start watcher
+			watch()
+				.paths( '*.cfc' )
+				.inDirectory( getCWD() )
+				.withDelay( 500 )
+				.onChange( function() {
+	
+					// Clear the screen
+					command( 'cls' )
+						.run();
+
+					// This is neccessary so changes to tests get picked up right away.
+					pagePoolClear();	
+					
+					runTests( solution );
+	
+				} )
+				.start();
+					
+		} else {
+			runTests( solution );
+		}			
+
+	}
+
+	/**
+	* Make sure the TestBox framework is installed
+	*/
+	private function ensureTestBox() {
+		var excerciseRoot = getCWD();
+		var testBoxRoot = excerciseRoot & '/testbox';
+		
+		if( !directoryExists( testBoxRoot ) ) {
+			
+			print.boldYellowLine( 'Installing some missing dependencies for you!' ).toConsole();
+			command( 'install' )
+				.inWorkingDirectory( excerciseRoot )
+				.run();
+		}
+		
+		// Bootstrap TestBox framework
+		filesystemUtil.createMapping( '/testbox', testBoxRoot );
+	}
+
+	/**
+	* Invoke TestBox to run the test suite
+	*/
+	private function runTests( boolean solution=false ) {
+		
+		// Create TestBox and run the tests
+		testData = new testbox.system.TestBox()
+			.runRaw( directory = {
+				// Find all CFCs...
+				mapping = filesystemUtil.makePathRelative( getCWD() ),
+				// ... in this directory ...
+				recurse = false,
+				// ... whose name ends in "test"
+				filter = function( path ) {
+					return path.reFind( ( solution ? 'Solution' : '' ) & 'Test.cfc$' );
+				 }
+			} )
+			.getMemento();
+		
+		// Print out the results with ANSI formatting for the CLI
+		getInstance( 'CLIRenderer@testbox-cli' )
+			.render( print, testData, true );
+			
+		print.toConsole();
+		
+		// Set proper exit code
+		if( testData.totalFail || testData.totalError ) {
+			setExitCode( 1 );
+		}
+	}
+
+}
+

--- a/exercises/practice/collatz-conjecture/box.json
+++ b/exercises/practice/collatz-conjecture/box.json
@@ -1,0 +1,8 @@
+{
+    "dependencies":{
+        "testbox":"^2.5.0+107"
+    },
+    "installPaths":{
+        "testbox":"testbox"
+    }
+}

--- a/exercises/practice/collatz-conjecture/index.cfm
+++ b/exercises/practice/collatz-conjecture/index.cfm
@@ -1,0 +1,37 @@
+<!--- 
+
+This file will only be used if you want to start up a web server in this directory.  You can do so by running:
+
+$> box
+CommandBox> install
+CommandBox> server start
+
+However, this is not necessary unless you really just want to use the HTML reporters on TestBox.  
+Ideally, you'll skip the need for this file entirely and just run the tests directly frm the CLI like this:
+
+CommandBox> task run TestRunner
+
+ --->
+<cfsetting showDebugOutput="false">
+<cfparam name="url.reporter" 		default="simple">
+<cfscript>
+	// get a list of all CFCs in this folder whose name looks like "XXXTest.cfc"
+	// And turn it into compnent path relative to the web root
+	url.bundles = directoryList(
+			path=expandPath( '/' ),
+			filter='*Test.cfc' )
+		.map( function( path ) {
+			return path
+					.replaceNoCase( expandPath( '/' ), '' )
+					.left( -4 )
+		} )
+		.toList();
+</cfscript>
+
+<!--- Ensure TestBox --->
+<cfif fileExists( "/testbox/system/runners/HTMLRunner.cfm" )>
+	<!--- Include the TestBox HTML Runner --->
+	<cfinclude template="/testbox/system/runners/HTMLRunner.cfm">
+<cfelse>
+	Oops, you don't have TestBox installed yet! Please run <b>box install</b> from the root of your exercise folder and refresh this page.	
+</cfif>


### PR DESCRIPTION
For #48in24.

In CommandBox 6, `CLIRenderer@testbox-commands` was renamed to `CLIRenderer@testbox-cli` so I'll follow up this weekend changing that for all already implemented exercises. It's used on line 91 of the TestRunner.cfc file.