### PR TITLE
Rename CLIRenderer@testbox-commands as CLIRenderer@testbox-cli

### DIFF
--- a/exercises/practice/acronym/TestRunner.cfc
+++ b/exercises/practice/acronym/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/all-your-base/TestRunner.cfc
+++ b/exercises/practice/all-your-base/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/allergies/TestRunner.cfc
+++ b/exercises/practice/allergies/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/anagram/TestRunner.cfc
+++ b/exercises/practice/anagram/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/atbash-cipher/TestRunner.cfc
+++ b/exercises/practice/atbash-cipher/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/binary-search/TestRunner.cfc
+++ b/exercises/practice/binary-search/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/bob/TestRunner.cfc
+++ b/exercises/practice/bob/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/circular-buffer/TestRunner.cfc
+++ b/exercises/practice/circular-buffer/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/darts/TestRunner.cfc
+++ b/exercises/practice/darts/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/diamond/TestRunner.cfc
+++ b/exercises/practice/diamond/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/difference-of-squares/TestRunner.cfc
+++ b/exercises/practice/difference-of-squares/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/dnd-character/TestRunner.cfc
+++ b/exercises/practice/dnd-character/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/eliuds-eggs/TestRunner.cfc
+++ b/exercises/practice/eliuds-eggs/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/etl/TestRunner.cfc
+++ b/exercises/practice/etl/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/flatten-array/TestRunner.cfc
+++ b/exercises/practice/flatten-array/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/gigasecond/TestRunner.cfc
+++ b/exercises/practice/gigasecond/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/grains/TestRunner.cfc
+++ b/exercises/practice/grains/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/hamming/TestRunner.cfc
+++ b/exercises/practice/hamming/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/hello-world/TestRunner.cfc
+++ b/exercises/practice/hello-world/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/isogram/TestRunner.cfc
+++ b/exercises/practice/isogram/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/largest-series-product/TestRunner.cfc
+++ b/exercises/practice/largest-series-product/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/leap/TestRunner.cfc
+++ b/exercises/practice/leap/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/list-ops/TestRunner.cfc
+++ b/exercises/practice/list-ops/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/luhn/TestRunner.cfc
+++ b/exercises/practice/luhn/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/markdown/TestRunner.cfc
+++ b/exercises/practice/markdown/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/nth-prime/TestRunner.cfc
+++ b/exercises/practice/nth-prime/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/nucleotide-count/TestRunner.cfc
+++ b/exercises/practice/nucleotide-count/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/pangram/TestRunner.cfc
+++ b/exercises/practice/pangram/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/perfect-numbers/TestRunner.cfc
+++ b/exercises/practice/perfect-numbers/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/pig-latin/TestRunner.cfc
+++ b/exercises/practice/pig-latin/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/protein-translation/TestRunner.cfc
+++ b/exercises/practice/protein-translation/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/queen-attack/TestRunner.cfc
+++ b/exercises/practice/queen-attack/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/raindrops/TestRunner.cfc
+++ b/exercises/practice/raindrops/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/resistor-color-duo/TestRunner.cfc
+++ b/exercises/practice/resistor-color-duo/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/resistor-color/TestRunner.cfc
+++ b/exercises/practice/resistor-color/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/reverse-string/TestRunner.cfc
+++ b/exercises/practice/reverse-string/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/rna-transcription/TestRunner.cfc
+++ b/exercises/practice/rna-transcription/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/robot-simulator/TestRunner.cfc
+++ b/exercises/practice/robot-simulator/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/roman-numerals/TestRunner.cfc
+++ b/exercises/practice/roman-numerals/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/run-length-encoding/TestRunner.cfc
+++ b/exercises/practice/run-length-encoding/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/saddle-points/TestRunner.cfc
+++ b/exercises/practice/saddle-points/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/scrabble-score/TestRunner.cfc
+++ b/exercises/practice/scrabble-score/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/secret-handshake/TestRunner.cfc
+++ b/exercises/practice/secret-handshake/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/space-age/TestRunner.cfc
+++ b/exercises/practice/space-age/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/square-root/TestRunner.cfc
+++ b/exercises/practice/square-root/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/strain/TestRunner.cfc
+++ b/exercises/practice/strain/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/sum-of-multiples/TestRunner.cfc
+++ b/exercises/practice/sum-of-multiples/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/triangle/TestRunner.cfc
+++ b/exercises/practice/triangle/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/two-fer/TestRunner.cfc
+++ b/exercises/practice/two-fer/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/exercises/practice/word-count/TestRunner.cfc
+++ b/exercises/practice/word-count/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();

--- a/tasks/exercise_template/TestRunner.cfc
+++ b/tasks/exercise_template/TestRunner.cfc
@@ -88,7 +88,7 @@ component {
 			.getMemento();
 		
 		// Print out the results with ANSI formatting for the CLI
-		getInstance( 'CLIRenderer@testbox-commands' )
+		getInstance( 'CLIRenderer@testbox-cli' )
 			.render( print, testData, true );
 			
 		print.toConsole();


### PR DESCRIPTION
In CommandBox 6, `CLIRenderer@testbox-commands` was renamed to ` CLIRenderer@testbox-cli`, breaking locally run tests. This was  used for printing the test results with ANSI formatting according to TestRunner.cfc comments.