### PR TITLE
Update the Grains example to pass the tests

### DIFF
--- a/exercises/practice/grains/.meta/Example.cfc
+++ b/exercises/practice/grains/.meta/Example.cfc
@@ -14,12 +14,10 @@ component {
 	}
 	
 	function total( input ) {
-		var total = 0;
-		loop from=1 to=64 index='local.i' {
-			total += square( i );
-		}
-		
-		return total;
+		var base = createObject("java","java.math.BigInteger").init( 2 );
+		var power = createObject("java","java.math.BigInteger").init( 64 );
+		var one = createObject("java","java.math.BigInteger").init( 1 );
+		return base.pow( power ).subtract( one ).toString();
 	}
 	
 }

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -3,6 +3,7 @@
     "bdw429s"
   ],
   "contributors": [
+    "IsaacG",
     "kytrinyx"
   ],
   "files": {

--- a/exercises/practice/grains/GrainsTest.cfc
+++ b/exercises/practice/grains/GrainsTest.cfc
@@ -53,7 +53,7 @@ component extends="testbox.system.BaseSpec" {
 			});
 
 			it( 'returns the total number of grains on the board', function(){
-				expect( SUT.total() ).toBe( 18446744073709551615 );
+				expect( SUT.total() ).toBe( '18446744073709551615' );
 			});
 
 		});


### PR DESCRIPTION
This is part of #302

This changes the `total()` test to expect a string, similar to the `square()` tests.
